### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+sudo: false
+cache: bundler
+
+before_install:
+  - gem update --system
+  - gem install bundler
+
+services:
+  - postgresql
+
+script:
+  - HANAMI_ENV=test bundle exec hanami db create
+  - HANAMI_ENV=test bundle exec hanami db migrate
+  - bundle exec rake


### PR DESCRIPTION
Two hours later and I figured out how this works. This runs all specs, but also caches the `gem install bundler` so it only needs to be run once. Installing bundler here is necessary because of [this issue](https://docs.travis-ci.com/user/languages/ruby/#bundler-20).

Now I will figure out what to do next with this.