### PR TITLE
Add rounding to data sent by endpoint

### DIFF
--- a/lib/typinggame_server/interactors/players_rooms/build_player_global_stats.rb
+++ b/lib/typinggame_server/interactors/players_rooms/build_player_global_stats.rb
@@ -66,10 +66,10 @@ module Interactors
         average_letters_typed = total_letters_typed / games_played.size
 
         {
-          average_wpm: average_wpm,
-          average_accuracy: average_accuracy,
+          average_wpm: average_wpm.round,
+          average_accuracy: average_accuracy.round(1),
           total_mistakes: total_mistakes,
-          average_mistakes: average_mistakes,
+          average_mistakes: average_mistakes.round,
           total_words_typed: total_words_typed,
           average_words_typed: average_words_typed,
           total_letters_typed: total_letters_typed,


### PR DESCRIPTION
There was a descrepency in the client where data received could look
like "96.6666666667" for things like accuracy. Because we apply this
rounding elsewhere on the server, we can opt to do it here as well,
rather than on the client side. This way we know where to look if things
go wrong.