### PR TITLE
Reverse player_room records for building stats

### DIFF
--- a/lib/typinggame_server/interactors/players_rooms/fetch_player_global_stats.rb
+++ b/lib/typinggame_server/interactors/players_rooms/fetch_player_global_stats.rb
@@ -18,6 +18,7 @@ module Interactors
 
         records =
           @player_room_repository.find_player_room_records(player_id: player.id)
+            .reverse
 
         @player_stats =
           BuildPlayerGlobalStats.new.call(records: records).player_stats


### PR DESCRIPTION
The client presents the game history in a scrollable box. It makes sense
to me to display the latest game first. By reversing the array of
game records we achieve this as the client renders the games from
position 0.

I opted to do the reverse here instead of in the repository because
there is a chance we might want to use the repository method without
reversing the games played at some point.